### PR TITLE
Temp

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,8 @@ Arduino Library to enable easy use of the Excelsior-Brick thought as a replaceme
   - Default is still the button press if Knopf() is called in main
 ### Version 1.0.7
 - Bug Fixes
+### Version 1.0.8
+- Added more function to autoreset of the gyro:
+  - gyroSpan now sets an interval in which the autoreset doesn't reset: defaul interval is [10,200]. Note that this deals with the absolute gyroValues
+  - Added function GyroResetSpann(int, int) to manually set this interval
+- Added function absolute that is not part of the Excelsior class, which returns the absolute Value of any int, double, float, long

--- a/keywords.txt
+++ b/keywords.txt
@@ -21,12 +21,15 @@ SensorWert	KEYWORD2
 GyroWert	KEYWORD2
 GyroReset	KEYWORD2
 GyroVerzoegerung	KEYWORD2
+GyroResetSpann	KEYWORD2
 DisplayAktualisieren	KEYWORD2
 DA	KEYWORD2
 DisplayText	KEYWORD2
 DT	KEYWORD2
 DisplayRand	KEYWORD2
 DR	KEYWORD2
+absolute	KEYWORD2
+
 
 #######################################
 # Constants (LITERAL1)

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Excelsior
-version=1.0.7
+version=1.0.8
 author=Frederik Eberhard, Tim Hartman
 maintainer=Frederik Eberhard <frederik.eberhard@gbg-seelze.eu>
 sentence=Functions as a beginners guide to programm the Excelsior™ LEGO© replacement Brick.

--- a/src/Excelsior.cpp
+++ b/src/Excelsior.cpp
@@ -256,7 +256,12 @@ int Excelsior::GyroWert(int axis, bool autoreset){    //0,1,2 --> The returned a
   if(autoreset){
     _gyroCalls++;
     if(_gyroCalls % _gyroresetDelay == 0){
-      GyroReset();
+      if(absolute(x) < _gyroSpan[0] || absolute(x) > _gyroSpan[1])
+        GyroReset(GYRO_X);
+      if(absolute(y) < _gyroSpan[0] || absolute(y) > _gyroSpan[1])
+        GyroReset(GYRO_X);
+      if(absolute(z) < _gyroSpan[0] || absolute(z) > _gyroSpan[1])
+        GyroReset(GYRO_X);
     }
   }
 
@@ -306,6 +311,12 @@ void Excelsior::GyroReset(int axis, bool toOriginal){          //Resets the Gyro
 void Excelsior::GyroVerzoegerung(int delay){
   _gyroresetDelay = delay;
 }
+
+void Excelsior::GyroResetSpann(int a, int b){
+  _gyroSpan[0] = a;
+  _gyroSpan[1] = b;
+}
+
 
 //------OLED DISPLAY------------------
 void Excelsior::DisplayAktualisieren(){

--- a/src/Excelsior.h
+++ b/src/Excelsior.h
@@ -51,6 +51,7 @@ class Excelsior
     void GyroReset(int axis);
     void GyroReset(int axis, bool toOriginal);
     void GyroVerzoegerung(int delay);
+    void GyroResetSpann(int a, int b);
     void DisplayAktualisieren();
     void DA();
     void DA(int type);
@@ -95,6 +96,7 @@ class Excelsior
     int _lightDelay = 1;                                  //not realy neccessary to have a higher number, as even 1 millisecond doesnt reduce the quality of the brightnesvalue
     int _gyroresetDelay = 100;
     int _gyroCalls = 0;
+    int _gyroSpan[2] = {10,200};                             //a Span, where if gyroValues fall inside of it, they wont get reset by autoreset
 
     int _sensors[_maxSensors];
     int _sensorValues[_maxSensors + 7];                   //stores the values of all sensors, the used gyroscope values the gyroscope reset values and the button
@@ -103,5 +105,16 @@ class Excelsior
     String _Display[_DisplayX][_DisplayY];                //stores what is supposed to be shown on the display
     bool _displayOutline = false;
 };
+
+template<typename type> type absolute(type v){
+  if(v < 0)
+    return -1 * v;
+  return v;
+}
+
+template double absolute(double);
+template int absolute(int);
+template float absolute(float);
+template long absolute(long);
 
 #endif


### PR DESCRIPTION
Added more function to autoreset of the gyro:
- gyroSpan now sets an interval in which the autoreset doesn't reset: defaul interval is [10,200]. Note that this deals with the absolute gyroValues
- Added function GyroResetSpann(int, int) to manually set this interval
Added function absolute that is not part of the Excelsior class, which returns the absolute Value of any int, double, float, long